### PR TITLE
Prevent unused parameter with none()

### DIFF
--- a/include/simple_match/implementation/some_none.hpp
+++ b/include/simple_match/implementation/some_none.hpp
@@ -159,6 +159,8 @@ namespace simple_match {
 
 			template<class T>
 			auto get(T&& t) {
+				// Prevent the warning "unused parameter 't' [-Wunused-parameter]"
+				(void) t;
 				return std::tie();
 			}
 		};

--- a/include/simple_match/implementation/some_none.hpp
+++ b/include/simple_match/implementation/some_none.hpp
@@ -158,9 +158,7 @@ namespace simple_match {
 			}
 
 			template<class T>
-			auto get(T&& t) {
-				// Prevent the warning "unused parameter 't' [-Wunused-parameter]"
-				(void) t;
+			auto get(T&&) {
 				return std::tie();
 			}
 		};


### PR DESCRIPTION
Prevent the `unused-parameter` warning when using `none()`.

This commit uses a void expression to explicitly mark this variable as unused so the compiler does not raise any warning.

Reference:
- [Stack Overflow: How do I best silence a warning about unused variables?][1]

[1]: http://stackoverflow.com/a/1486931/2487009