### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Simple, Extensible C++ Pattern Matching Library
+# Simple, Extensible C++ Pattern Matching Library
 
 I have recently been looking at Haskell and Rust. One of the things I wanted in C++ from those languages is pattern matching.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
